### PR TITLE
Rework how arguments are passed to Log() + add possibility to clamp the log level

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -2,6 +2,7 @@ package glog
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/go-kit/kit/log"
@@ -23,197 +24,106 @@ type Verbose bool
 
 func V(level Level) Verbose { return true }
 
+func logMsg(l log.Logger, f string, msg string) {
+	l.Log("func", f, "msg", msg)
+}
+
 func (v Verbose) Info(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Verbose.Info")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Debug(logger).Log(pairs...)
+	logMsg(level.Debug(logger), "Verbose.Info", fmt.Sprint(args...))
 }
 
 func (v Verbose) Infoln(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Verbose.Infoln")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Debug(logger).Log(pairs...)
+	logMsg(level.Debug(logger), "Verbose.Infoln", fmt.Sprint(args...))
 }
 
 func (v Verbose) Infof(format string, args ...interface{}) {
-	level.Debug(logger).Log(
-		"func", "Infof",
-		"msg", fmt.Sprintf(format, args...),
-	)
+	logMsg(level.Debug(logger), "Verbose.Infof", fmt.Sprintf(format, args...))
 }
 
 func Info(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Info")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Debug(logger).Log(pairs...)
+	logMsg(level.Debug(logger), "Info", fmt.Sprint(args...))
 }
 
 func InfoDepth(depth int, args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "InfoDepth")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Debug(logger).Log(pairs...)
+	logMsg(level.Debug(logger), "InfoDepth", fmt.Sprint(args...))
 }
 
 func Infoln(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Infoln")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Debug(logger).Log(pairs...)
+	logMsg(level.Debug(logger), "Infoln", fmt.Sprint(args...))
 }
 
 func Infof(format string, args ...interface{}) {
-	level.Debug(logger).Log(
-		"func", "Infof",
-		"msg", fmt.Sprintf(format, args...),
-	)
+	logMsg(level.Debug(logger), "Infof", fmt.Sprintf(format, args...))
 }
 
 func Warning(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Warning")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Warn(logger).Log(pairs...)
+	logMsg(level.Warn(logger), "Warning", fmt.Sprint(args...))
 }
 
 func WarningDepth(depth int, args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "WarningDepth")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Warn(logger).Log(pairs...)
+	logMsg(level.Warn(logger), "WarningDepth", fmt.Sprint(args...))
 }
 
 func Warningln(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Warningln")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Warn(logger).Log(pairs...)
+	logMsg(level.Warn(logger), "Warningln", fmt.Sprint(args...))
 }
 
 func Warningf(format string, args ...interface{}) {
-	level.Warn(logger).Log(
-		"func", "Warningf",
-		"msg", fmt.Sprintf(format, args...),
-	)
+	logMsg(level.Warn(logger), "Warningf", fmt.Sprintf(format, args...))
 }
 
 func Error(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Error")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "Error", fmt.Sprint(args...))
 }
 
 func ErrorDepth(depth int, args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "ErrorDepth")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "ErrorDepth", fmt.Sprint(args...))
 }
 
 func Errorln(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Errorln")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "Errorln", fmt.Sprint(args...))
 }
 
 func Errorf(format string, args ...interface{}) {
-	level.Error(logger).Log(
-		"func", "Errorf",
-		"msg", fmt.Sprintf(format, args...),
-	)
+	logMsg(level.Error(logger), "Errorf", fmt.Sprintf(format, args...))
 }
 
 func Fatal(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Fatal")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "Fatal", fmt.Sprint(args...))
+	os.Exit(255)
 }
 
 func FatalDepth(depth int, args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "FatalDepth")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "FatalDepth", fmt.Sprint(args...))
+	os.Exit(255)
 }
 
 func Fatalln(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Fatalln")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "Fatalln", fmt.Sprint(args...))
+	os.Exit(255)
 }
 
 func Fatalf(format string, args ...interface{}) {
-	level.Error(logger).Log(
-		"func", "Fatalf",
-		"msg", fmt.Sprintf(format, args...),
-	)
+	logMsg(level.Error(logger), "Fatalf", fmt.Sprintf(format, args...))
+	os.Exit(255)
 }
 
 func Exit(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Exit")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "Exit", fmt.Sprint(args...))
+	os.Exit(1)
 }
 
 func ExitDepth(depth int, args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "ExitDepth")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "ExitDepth", fmt.Sprint(args...))
+	os.Exit(1)
 }
 
 func Exitln(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "func", "Exitln")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
-	}
-	level.Error(logger).Log(pairs...)
+	logMsg(level.Error(logger), "ExitDepth", fmt.Sprint(args...))
+	os.Exit(1)
 }
 
 func Exitf(format string, args ...interface{}) {
-	level.Error(logger).Log(
-		"func", "Exitf",
-		"msg", fmt.Sprintf(format, args...),
-	)
+	logMsg(level.Error(logger), "Exit", fmt.Sprintf(format, args...))
+	os.Exit(1)
 }

--- a/glog.go
+++ b/glog.go
@@ -36,112 +36,108 @@ type Verbose bool
 
 func V(level Level) Verbose { return level <= maxLevel }
 
-func logMsg(l log.Logger, f string, msg string) {
-	l.Log("func", f, "msg", msg)
-}
-
 func (v Verbose) Info(args ...interface{}) {
 	if v {
-		logMsg(level.Debug(logger), "Verbose.Info", fmt.Sprint(args...))
+		level.Debug(logger).Log("func", "Verbose.Info", "msg", fmt.Sprint(args...))
 	}
 }
 
 func (v Verbose) Infoln(args ...interface{}) {
 	if v {
-		logMsg(level.Debug(logger), "Verbose.Infoln", fmt.Sprint(args...))
+		level.Debug(logger).Log("func", "Verbose.Infoln", "msg", fmt.Sprint(args...))
 	}
 }
 
 func (v Verbose) Infof(format string, args ...interface{}) {
 	if v {
-		logMsg(level.Debug(logger), "Verbose.Infof", fmt.Sprintf(format, args...))
+		level.Debug(logger).Log("func", "Verbose.Infof", "msg", fmt.Sprintf(format, args...))
 	}
 }
 
 func Info(args ...interface{}) {
-	logMsg(level.Debug(logger), "Info", fmt.Sprint(args...))
+	level.Debug(logger).Log("func", "Info", "msg", fmt.Sprint(args...))
 }
 
 func InfoDepth(depth int, args ...interface{}) {
-	logMsg(level.Debug(logger), "InfoDepth", fmt.Sprint(args...))
+	level.Debug(logger).Log("func", "InfoDepth", "msg", fmt.Sprint(args...))
 }
 
 func Infoln(args ...interface{}) {
-	logMsg(level.Debug(logger), "Infoln", fmt.Sprint(args...))
+	level.Debug(logger).Log("func", "Infoln", "msg", fmt.Sprint(args...))
 }
 
 func Infof(format string, args ...interface{}) {
-	logMsg(level.Debug(logger), "Infof", fmt.Sprintf(format, args...))
+	level.Debug(logger).Log("func", "Infof", "msg", fmt.Sprintf(format, args...))
 }
 
 func Warning(args ...interface{}) {
-	logMsg(level.Warn(logger), "Warning", fmt.Sprint(args...))
+	level.Warn(logger).Log("func", "Warning", "msg", fmt.Sprint(args...))
 }
 
 func WarningDepth(depth int, args ...interface{}) {
-	logMsg(level.Warn(logger), "WarningDepth", fmt.Sprint(args...))
+	level.Warn(logger).Log("func", "WarningDepth", "msg", fmt.Sprint(args...))
 }
 
 func Warningln(args ...interface{}) {
-	logMsg(level.Warn(logger), "Warningln", fmt.Sprint(args...))
+	level.Warn(logger).Log("func", "Warningln", "msg", fmt.Sprint(args...))
 }
 
 func Warningf(format string, args ...interface{}) {
-	logMsg(level.Warn(logger), "Warningf", fmt.Sprintf(format, args...))
+	level.Warn(logger).Log("func", "Warningf", "msg", fmt.Sprintf(format, args...))
 }
 
 func Error(args ...interface{}) {
-	logMsg(level.Error(logger), "Error", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "Error", "msg", fmt.Sprint(args...))
 }
 
 func ErrorDepth(depth int, args ...interface{}) {
-	logMsg(level.Error(logger), "ErrorDepth", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "ErrorDepth", "msg", fmt.Sprint(args...))
 }
 
 func Errorln(args ...interface{}) {
-	logMsg(level.Error(logger), "Errorln", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "Errorln", "msg", fmt.Sprint(args...))
 }
 
 func Errorf(format string, args ...interface{}) {
-	logMsg(level.Error(logger), "Errorf", fmt.Sprintf(format, args...))
+	level.Error(logger).Log("func", "Errorf", "msg", fmt.Sprintf(format, args...))
 }
 
 func Fatal(args ...interface{}) {
-	logMsg(level.Error(logger), "Fatal", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "Fatal", "msg", fmt.Sprint(args...))
 	os.Exit(255)
 }
 
 func FatalDepth(depth int, args ...interface{}) {
-	logMsg(level.Error(logger), "FatalDepth", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "FatalDepth", "msg", fmt.Sprint(args...))
 	os.Exit(255)
 }
 
 func Fatalln(args ...interface{}) {
-	logMsg(level.Error(logger), "Fatalln", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "Fatalln", "msg", fmt.Sprint(args...))
 	os.Exit(255)
 }
 
 func Fatalf(format string, args ...interface{}) {
-	logMsg(level.Error(logger), "Fatalf", fmt.Sprintf(format, args...))
+	level.Error(logger).Log("func", "Fatalf", "msg", fmt.Sprintf(format, args...))
 	os.Exit(255)
 }
 
 func Exit(args ...interface{}) {
-	logMsg(level.Error(logger), "Exit", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "Exit", "msg", fmt.Sprint(args...))
 	os.Exit(1)
 }
 
 func ExitDepth(depth int, args ...interface{}) {
-	logMsg(level.Error(logger), "ExitDepth", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "ExitDepth", "msg", fmt.Sprint(args...))
 	os.Exit(1)
 }
 
 func Exitln(args ...interface{}) {
-	logMsg(level.Error(logger), "ExitDepth", fmt.Sprint(args...))
+	level.Error(logger).Log("func", "Exitln", "msg", fmt.Sprint(args...))
 	os.Exit(1)
 }
 
 func Exitf(format string, args ...interface{}) {
-	logMsg(level.Error(logger), "Exit", fmt.Sprintf(format, args...))
+	level.Error(logger).Log("func", "Exitf", "msg", fmt.Sprintf(format, args...))
 	os.Exit(1)
 }

--- a/glog_test.go
+++ b/glog_test.go
@@ -30,19 +30,19 @@ func TestInfo(t *testing.T) {
 	}{{
 		Name:     "String",
 		Args:     []interface{}{"foo"},
-		Expected: `{"0":"foo", "func":"Info", "level":"debug"}`,
+		Expected: `{"msg":"foo", "func":"Info", "level":"debug"}`,
 	}, {
 		Name:     "Int",
 		Args:     []interface{}{42},
-		Expected: `{"0":42, "func":"Info", "level":"debug"}`,
+		Expected: `{"msg":"42", "func":"Info", "level":"debug"}`,
 	}, {
 		Name:     "Bool",
 		Args:     []interface{}{true},
-		Expected: `{"0":true, "func":"Info", "level":"debug"}`,
+		Expected: `{"msg":"true", "func":"Info", "level":"debug"}`,
 	}, {
 		Name:     "StringInt",
 		Args:     []interface{}{"foo", 42},
-		Expected: `{"0":"foo", "1": 42, "func":"Info", "level":"debug"}`,
+		Expected: `{"msg":"foo42", "func":"Info", "level":"debug"}`,
 	}}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
This change is two-fold but I can split it if necessary:
* Instead of passing the arguments as-is to `logger.Log()`, this PR formats them as required (`fmt.Sprint`, `fmt.Sprintf`) and logs the result string with the `msg` key.
* If you configure the go-kit logger at `debug` level, all glog logs will be displayed. The reason for clamping the max log level is that some libraries (eg k8s client) log sensitive information like authentication data above a certain level.

Example log from Prometheus:

```
level=debug ts=2018-11-28T15:41:11.079848979Z caller=glog.go:40 component=k8s_client_runtime func=Verbose.Infof msg="Starting reflector *v1.Endpoints (10m0s) from github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:300"
level=debug ts=2018-11-28T15:41:11.081195865Z caller=glog.go:40 component=k8s_client_runtime func=Verbose.Infof msg="Listing and watching *v1.Endpoints from github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:300"
level=debug ts=2018-11-28T15:41:11.110272719Z caller=glog.go:40 component=k8s_client_runtime func=Infof msg="GET https://172.30.0.1:443/api/v1/namespaces/myproject/services?limit=500&resourceVersion=0 200 OK in 30 milliseconds"
level=debug ts=2018-11-28T15:41:11.110295625Z caller=glog.go:40 component=k8s_client_runtime func=Infof msg="GET https://172.30.0.1:443/api/v1/namespaces/myproject/endpoints?limit=500&resourceVersion=0 200 OK in 28 milliseconds"
level=debug ts=2018-11-28T15:41:11.110308592Z caller=glog.go:40 component=k8s_client_runtime func=Infof msg="GET https://172.30.0.1:443/api/v1/namespaces/myproject/pods?limit=500&resourceVersion=0 200 OK in 29 milliseconds"
level=debug ts=2018-11-28T15:41:11.11654008Z caller=glog.go:40 component=k8s_client_runtime func=Infof msg="GET https://172.30.0.1:443/api/v1/namespaces/myproject/services?resourceVersion=3020&timeoutSeconds=519&watch=true 200 OK in 2 milliseconds"
level=debug ts=2018-11-28T15:41:11.118020281Z caller=glog.go:40 component=k8s_client_runtime func=Infof msg="GET https://172.30.0.1:443/api/v1/namespaces/myproject/endpoints?resourceVersion=3986&timeoutSeconds=456&watch=true 200 OK in 3 milliseconds"
level=debug ts=2018-11-28T15:41:11.122390828Z caller=glog.go:40 component=k8s_client_runtime func=Infof msg="GET https://172.30.0.1:443/api/v1/namespaces/myproject/pods?resourceVersion=3991&timeoutSeconds=358&watch=true 200 OK in 0 milliseconds"
level=debug ts=2018-11-28T15:41:11.178835874Z caller=glog.go:40 component=k8s_client_runtime func=Verbose.Infof msg="caches populated"
```