### PR TITLE
Add Flush() stub

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -141,3 +141,5 @@ func Exitf(format string, args ...interface{}) {
 	level.Error(logger).Log("func", "Exitf", "msg", fmt.Sprintf(format, args...))
 	os.Exit(1)
 }
+
+func Flush() {}


### PR DESCRIPTION
`github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway` and `grpc-ecosystem/grpc-gateway/protoc-gen-swagger` both call `glog.Flush()`.